### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Update
 
-You can install the app directly through `brew cask install clock-bar`
+You can install the app directly through `brew install cask clock-bar`
 
 # Clock Bar
 Get clock right on the sweetest spot of the macbook, on the touch bar.


### PR DESCRIPTION
the previous installation command returns the following error string: 

`Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.`